### PR TITLE
Add two player support and configuration for ps4 controller

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,8 +9,6 @@ parser.add_argument('--port', '-p',
 parser.add_argument('--opponent', '-o',
                     help='The controller port the opponent will play on',
                     default=1)
-parser.add_argument('--mode', '-m', help='Mode of gym_melee (watch | play)',
-                    default='watch')
 parser.add_argument('--controller', '-i',
                     help='The controller type, options are gcna, ps4, xbox, bot and unplugged',
                     default='gcna')
@@ -27,7 +25,6 @@ args = parser.parse_args()
 character = args.character
 stage = args.stage
 debug = args.debug
-mode = args.mode
 
 # tells controller type (standard, gc, etc.)
 # STANDARD = "6"
@@ -46,7 +43,7 @@ env = gym_melee.MeleeEnv(stage, controller_type=controller_type,
 player = gym_melee.RLPlayer(character, env.get_ai_controller(), debug=debug)
 
 # Game loop
-env.start(mode, 'Super Smash Bros. Melee (v1.02).iso')
+env.start('Super Smash Bros. Melee (v1.02).iso')
 while True:
     dframe = env.step(player).ai
     if dframe.dead:

--- a/example.py
+++ b/example.py
@@ -2,16 +2,20 @@
 import argparse
 import gym_melee
 
-parser = argparse.ArgumentParser(description='Example of libmelee in action')
+parser = argparse.ArgumentParser(description='Example gym_melee')
 parser.add_argument('--port', '-p',
                     help='The controller port your AI will play on',
                     default=2)
 parser.add_argument('--opponent', '-o',
                     help='The controller port the opponent will play on',
                     default=1)
+parser.add_argument('--mode', '-m', help='Mode of gym_melee (watch | play)',
+                    default='watch')
 parser.add_argument('--controller', '-i',
                     help='The controller type, options are gcna, ps4, xbox, bot and unplugged',
                     default='gcna')
+parser.add_argument('--aicontroller', '-a',
+                    help='Should the ai port play as a bot or read from a controller same options as in --controller')
 parser.add_argument('--debug', '-d', action='store_true',
                     help='Debug mode.')
 parser.add_argument('--character', '-c', default='fox',
@@ -23,6 +27,7 @@ args = parser.parse_args()
 character = args.character
 stage = args.stage
 debug = args.debug
+mode = args.mode
 
 # tells controller type (standard, gc, etc.)
 # STANDARD = "6"
@@ -30,17 +35,18 @@ debug = args.debug
 # UNPLUGGED = "0"
 # XBOX = "2"
 # PS4 = "4"
-controller = args.controller
+controller_type = args.controller
+ai_controller_type = args.aicontroller
 
 # Starts dolphin, inits some stuff.
-env = gym_melee.MeleeEnv(stage, controllertype=controller, debug=debug)
+env = gym_melee.MeleeEnv(stage, controller_type=controller_type,
+                    ai_controller_type=ai_controller_type, debug=debug)
 
 # The ai player
-# TODO: use a real player
 player = gym_melee.RLPlayer(character, env.get_ai_controller(), debug=debug)
 
 # Game loop
-env.start('Super Smash Bros. Melee (v1.02).iso')
+env.start(mode, 'Super Smash Bros. Melee (v1.02).iso')
 while True:
     dframe = env.step(player).ai
     if dframe.dead:

--- a/gym_melee/env.py
+++ b/gym_melee/env.py
@@ -64,12 +64,12 @@ class MeleeEnv(object):
         signal.signal(signal.SIGINT, signal_handler)
 
     # IDEA: add auto_train feature
-    def start(self, mode, iso_path):
+    def start(self, iso_path):
         if self.opponent_type == melee.enums.ControllerType.UNPLUGGED:
             self.dolphin.run(render=True)
         else:
             self.dolphin.run(render=True, iso_path=iso_path)
-        if self.controller and mode == 'play':
+        if self.controller:
             self.controller.connect()
 
     def step(self, watcher):

--- a/gym_melee/env.py
+++ b/gym_melee/env.py
@@ -14,7 +14,8 @@ class MeleeEnv(object):
     Rewards are proportional to taken (negative) and provoked (Positive) damage.
     Aditionally, a correct use of shield and dodge yields small positive rewards.
     """
-    def __init__(self, stage, opponent_port=1, ai_port=2, controllertype='gcna', debug=False):
+    def __init__(self, stage, opponent_port=1, ai_port=2, controller_type='gcna',
+            ai_controller_type='standard', debug=False):
         check_port(opponent_port)
         check_port(ai_port)
         self.framesaves = os.path.join(os.path.realpath(os.path.curdir), "saves")
@@ -25,12 +26,13 @@ class MeleeEnv(object):
         self.ai_port = ai_port
         self.ai_character = 'generic'
         self.stage = parse_stage(stage)
-        self.opponent_type = parse_controller(controllertype)
+        self.opponent_type = parse_controller(controller_type)
+        ai_type = parse_controller(ai_controller_type)
         self.framedata = melee.framedata.FrameData(True)
 
         # Create our Dolphin object. This will be the primary object that we will interface with
         self.dolphin = melee.dolphin.Dolphin(ai_port=ai_port, opponent_port=opponent_port,
-            opponent_type=self.opponent_type, logger=self.log)
+            opponent_type=self.opponent_type, ai_type=ai_type, logger=self.log)
         # Create our GameState object for the dolphin instance
         self.gamestate = melee.gamestate.GameState(self.dolphin)
         self.deltastate = FrameDelta(self.gamestate)
@@ -62,12 +64,12 @@ class MeleeEnv(object):
         signal.signal(signal.SIGINT, signal_handler)
 
     # IDEA: add auto_train feature
-    def start(self, iso_path):
+    def start(self, mode, iso_path):
         if self.opponent_type == melee.enums.ControllerType.UNPLUGGED:
             self.dolphin.run(render=True)
         else:
             self.dolphin.run(render=True, iso_path=iso_path)
-        if self.controller:
+        if self.controller and mode == 'play':
             self.controller.connect()
 
     def step(self, watcher):

--- a/melee/dolphin.py
+++ b/melee/dolphin.py
@@ -6,7 +6,7 @@ from melee import enums
 class Dolphin:
 
     """Do a some setup of some important dolphin paths"""
-    def __init__(self, ai_port, opponent_port, opponent_type, logger=None):
+    def __init__(self, ai_port, opponent_port, opponent_type, ai_type=enums.ControllerType.STANDARD, logger=None):
         self.ai_port = ai_port
         self.opponent_port = opponent_port
         self.logger = logger
@@ -38,7 +38,7 @@ class Dolphin:
             os.mkfifo(pipes_path)
 
         #setup the controllers specified
-        self.setup_controller(ai_port)
+        self.setup_controller(ai_port, ai_type)
         self.setup_controller(opponent_port, opponent_type)
 
     """Setup the necessary files for dolphin to recognize the player at the given
@@ -86,8 +86,39 @@ class Dolphin:
         #This section is unused if it's not a standard input (I think...)
         elif controllertype == enums.ControllerType.PS4:
             config.set(section, 'Device', 'evdev/0/Wireless Controller')
+            config.set(section, 'Buttons/A', 'Button 2')
+            config.set(section, 'Buttons/B', 'Button 1')
+            config.set(section, 'Buttons/X', 'Button 0')
+            config.set(section, 'Buttons/Y', 'Button 3')
+            config.set(section, 'Buttons/Z', 'Button 5')
+            config.set(section, 'Buttons/L', 'Button 6')
+            config.set(section, 'Buttons/R', 'Button 7')
+            config.set(section, 'Main Stick/Up', 'Axis 1-')
+            config.set(section, 'Main Stick/Down', 'Axis 1+')
+            config.set(section, 'Main Stick/Left', 'Axis 0-')
+            config.set(section, 'Main Stick/Right', 'Axis 0+')
+            config.set(section, 'Triggers/L', 'Button 6')
+            config.set(section, 'Triggers/R', 'Button 7')
+            config.set(section, 'Main Stick/Modifier', 'Button 10')
+            config.set(section, 'Main Stick/Modifier/Range', '50.000000000000000')
+            config.set(section, 'D-Pad/Up', 'Axis 7-')
+            config.set(section, 'D-Pad/Down', 'Axis 7+')
+            config.set(section, 'D-Pad/Left', 'Axis 6-')
+            config.set(section, 'D-Pad/Right', 'Axis 6+')
+            config.set(section, 'Buttons/Start', 'Button 9')
+            config.set(section, 'Buttons/A', 'Button 2')
+            config.set(section, 'C-Stick/Up', 'Axis 5-')
+            config.set(section, 'C-Stick/Down', 'Axis 5+')
+            config.set(section, 'C-Stick/Left', 'Axis 2-')
+            config.set(section, 'C-Stick/Right', 'Axis 2+')
+            config.set(section, 'Triggers/L-Analog', '')
+            config.set(section, 'Triggers/R-Analog', '')
+            controllertype = enums.ControllerType.STANDARD
         else:
             config.set(section, 'Device', 'XInput2/0/Virtual core pointer')
+            # TODO: Add xbox controller configuration
+            controllertype = enums.ControllerType.STANDARD
+        # IDEA: Add keyboard support
 
         with open(controller_config_path, 'w') as configfile:
             config.write(configfile)


### PR DESCRIPTION
Solves #2, adds support for two watching two players instead of a player and a bot.
It also adds a default configuration for the PS4 controller.